### PR TITLE
Fix update-yabridge paths

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -32,12 +32,12 @@ if [ -d $HOME/.local/share/yabridge/ ]; then
   PATH=$PATH:$HOME/.local/share/yabridge/
 
   function update-yabridge () {
-    wget `docker run --rm ghcr.io/dvershinin/lastversion:latest robbert-vdh/yabridge --assets --filter '^((?!ubuntu).)*$'` -O /tmp/yabridge.tar.gz && \
-    cd /tmp && \
-    tar zxvf yabridge.tar.gz && \
-    rm -rf /home/omen/.local/share/yabridge/ && \
-    mv -f yabridge /home/omen/.local/share && \
-    rm /tmp/yabridge.tar.gz
+    wget "$(docker run --rm ghcr.io/dvershinin/lastversion:latest robbert-vdh/yabridge --assets --filter '^((?!ubuntu).)*$')" -O "/tmp/yabridge.tar.gz" && \
+    cd "/tmp" && \
+    tar zxvf "yabridge.tar.gz" && \
+    rm -rf "$HOME/.local/share/yabridge/" && \
+    mv -f "yabridge" "$HOME/.local/share" && \
+    rm "/tmp/yabridge.tar.gz"
     yabridgectl sync
   }
 fi


### PR DESCRIPTION
## Summary
- update yabridge function in `.zshrc` to use `$HOME`
- quote all file paths for reliability

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a521aa898832f896100648c81bc5c