### PR TITLE
Replace backtick use in zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -55,7 +55,7 @@ DISABLE_AUTO_TITLE="true"
 
 export VISUAL=vim
 export EDITOR=$VISUAL
-export DEFAULT_USER=`whoami`
+export DEFAULT_USER=$(whoami)
 
 # export DIRENV_LOG_FORMAT=
 # make it more responsive


### PR DESCRIPTION
## Summary
- clean up DEFAULT_USER export by replacing outdated backtick command

## Testing
- `make -n`

------
https://chatgpt.com/codex/tasks/task_e_685a5226b524832f8b77b92078d4a088