### PR TITLE
Update sourcing loop to handle spaces and missing files

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -455,9 +455,9 @@ else
 fi
 
 # Local includes
-if [ -d $HOME/.zshrc.d ]; then
-  for file in $HOME/.zshrc.d/*.zsh; do
-    source $file
+if [[ -d "$HOME/.zshrc.d" ]]; then
+  for file in "$HOME"/.zshrc.d/*.zsh(N); do
+    source "$file"
   done
 fi
 


### PR DESCRIPTION
## Summary
- update `.zshrc` loop to use zsh extended glob to handle spaces and missing matches

## Testing
- `make -n`

------
https://chatgpt.com/codex/tasks/task_e_685a522ba48c832fb98310fb2f21d7ee