### PR TITLE
Replace git_main_branch implementation

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -216,7 +216,8 @@ if has "git"; then
   alias git-fixup="ga . && git fixup -c --rebase && gpf"
 
   function git_main_branch () {
-    git branch -l master main | xargs | cut -f 2 -d ' '
+    git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null \
+      | sed 's@^refs/remotes/origin/@@'
   }
 
   function grhco () {


### PR DESCRIPTION
## Summary
- update `git_main_branch` to read origin HEAD

## Testing
- `zsh -n .zshrc` *(fails: `zsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a52326f04832fb1305ea33375777e