### PR TITLE
Use XDG locations for zsh history/cache

### DIFF
--- a/.zsh/zstyle.zsh
+++ b/.zsh/zstyle.zsh
@@ -14,7 +14,9 @@ LS_COLORS=${LS_COLORS:-'di=34:ln=35:so=32:pi=33:ex=31:bd=36;01:cd=33;01:su=31;40
 
 # enable caching to make completion for commands such as dpkg and apt usable
 zstyle ':completion::complete:*' use-cache on
-zstyle ':completion::complete:*' cache-path "${XDG_CACHE_HOME:-$HOME/.cache}/zcompcache"
+zcompcache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/zsh"
+mkdir -p "$zcompcache_dir"
+zstyle ':completion::complete:*' cache-path "$zcompcache_dir/zcompcache"
 
 # group matches and describe
 zstyle ':completion:*:*:*:*:*' menu select

--- a/.zshrc
+++ b/.zshrc
@@ -348,7 +348,9 @@ fi
 
 # https://martinheinz.dev/blog/110
 unsetopt SHARE_HISTORY
-export HISTFILE="$HOME/.zsh_history"
+# Store history in XDG compliant location
+export HISTFILE="${XDG_STATE_HOME:-$HOME/.local/state}/zsh/history"
+[[ ! -d ${HISTFILE:h} ]] && mkdir -p "${HISTFILE:h}"
 export HISTSIZE=1000000
 export HISTIGNORE="ignorespace"
 export SAVEHIST=1000000


### PR DESCRIPTION
## Summary
- store history under `${XDG_STATE_HOME}` with fallback
- keep completion cache under `${XDG_CACHE_HOME}/zsh`
- ensure the directories exist before using them

## Testing
- `make -n` *(fails: zsh not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a52bcb658832fb466f621b7cc019d