### PR TITLE
Add zsh syntax check workflow

### DIFF
--- a/.github/workflows/zsh-syntax-check.yml
+++ b/.github/workflows/zsh-syntax-check.yml
@@ -1,0 +1,27 @@
+name: Zsh Syntax Check
+
+on:
+  push:
+    paths:
+      - '.zshrc'
+      - '.zsh/**'
+  pull_request:
+    paths:
+      - '.zshrc'
+      - '.zsh/**'
+
+jobs:
+  zsh-syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check Zsh syntax
+        run: |
+          set -e
+          echo "zsh version: $(zsh --version)"
+          files=(.zshrc $(find .zsh -name '*.zsh'))
+          for f in "${files[@]}"; do
+            echo "Checking $f"
+            zsh -n "$f"
+          done
+


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs `zsh -n` on `.zshrc` and the scripts in `.zsh/`

## Testing
- `zsh --version` *(fails: command not found)*
- `sudo apt-get update -y` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685a53a71aac832f82630c66d7e1a992